### PR TITLE
Simplify const declaration for regex

### DIFF
--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -21,7 +21,7 @@ export class Utils {
 
   matchDomainPattern(url: string, domainPattern: string): boolean {
     if (domainPattern.startsWith('/')) {
-      const regexp = domainPattern.match(/^\s*\/(.*)\/([gimsuy]+)?\s*$/);
+      const regexp = domainPattern.match(/^\s*\/(.*)\/\s*$/);
       if (!regexp) {
         return false;
       }


### PR DESCRIPTION
I'm not sure about this... I noticed this strange literal within this `const` declaration.

If this literal is not needed, please accept the PR.  If it's needed, please reject the PR, and if you have time, explain why the matching that literal within the pattern is needed.  It looks like perhaps a literal for an exception that is possibly no longer needed.