### PR TITLE
fix: hardcode 'firefox' as container prefix for waterfox and librewolf

### DIFF
--- a/src/background/tmp.ts
+++ b/src/background/tmp.ts
@@ -96,8 +96,8 @@ export class TemporaryContainers {
       // Fix mismatch of Browser name and container prefix
       if(browserInfo.name.toLowerCase() == "waterfox" || browserInfo.name.toLowerCase() == "librewolf") {
         // container prefix values fetched from here: https://github.com/mozilla-firefox/firefox/blob/e4d8867f696477f5ec96db70d584716c6edb1213/toolkit/components/extensions/parent/ext-toolkit.js#L30
-        console.warn("WaterFox and Librewolf detected, fixing container prefix to 'firefox-default'");
-        this.storage.local.containerPrefix = "firefox-default";
+        console.warn("WaterFox and Librewolf detected, fixing container prefix to 'firefox'");
+        this.storage.local.containerPrefix = "firefox";
       } else {
         this.storage.local.containerPrefix = browserInfo.name.toLowerCase();
       }

--- a/src/background/tmp.ts
+++ b/src/background/tmp.ts
@@ -92,7 +92,16 @@ export class TemporaryContainers {
 
     if (!this.storage.local.containerPrefix) {
       const browserInfo = await browser.runtime.getBrowserInfo();
-      this.storage.local.containerPrefix = browserInfo.name.toLowerCase();
+
+      // Fix mismatch of Browser name and container prefix
+      if(browserInfo.name.toLowerCase() == "waterfox" || browserInfo.name.toLowerCase() == "librewolf") {
+        // container prefix values fetched from here: https://github.com/mozilla-firefox/firefox/blob/e4d8867f696477f5ec96db70d584716c6edb1213/toolkit/components/extensions/parent/ext-toolkit.js#L30
+        console.warn("WaterFox and Librewolf detected, fixing container prefix to 'firefox-default'");
+        this.storage.local.containerPrefix = "firefox-default";
+      } else {
+        this.storage.local.containerPrefix = browserInfo.name.toLowerCase();
+      }
+      
       await this.storage.persist();
     }
     this.containerPrefix = this.storage.local.containerPrefix;


### PR DESCRIPTION
### Problem

Temporary Containers Automatic mode is not working on firefox forks which customize the value returned as the browser name.

The mismatch means the extension crashes when a new tab opens, an error prints out at the console and the container for the new tab is not created.

### Solution

Check if the browser is WaterFox or LibreWolf and then hardcode `firefox-default` as the container prefix.

I think ideally we would query the browser for the default prefix name (but not sure how to do that as of now)


LibreWolf issue: https://codeberg.org/librewolf/issues/issues/2669
Temporary Containers Issue: https://github.com/stoically/temporary-containers/issues/335